### PR TITLE
Relax NodeJS version restrictions in package.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name": "govuk-rails-boilerplate",
+  "name": "register-trainee-teacher-data",
   "scripts": {
     "postdeploy": "bundle exec rake db:migrate db:seed"
   },

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "register-trainee-teacher-data",
   "scripts": {
-    "postdeploy": "bundle exec rake db:migrate db:seed"
+    "postdeploy": "RAILS_ENV=production bundle exec rake db:schema:load db:seed"
   },
   "env": {
     "LANG": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": "12.18.3"
+    "node": "12.x"
   },
   "dependencies": {
     "@rails/webpacker": "^5.1.1",


### PR DESCRIPTION
### Context
We shouldn't stress over using the exact version of node js as long
as we are using version 12 we should be alright.

It also means that Heroku review apps will work because Heroku build pack
does not use the latest LTS version.
### Changes proposed in this pull request

### Guidance to review

