### PR TITLE
[25] Able to add previous education to trainee

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ group :development do
 end
 
 group :test do
+  gem "faker"
   gem "webdrivers", "~> 4.4"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
+    faker (2.13.0)
+      i18n (>= 1.6, < 2)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
@@ -289,6 +291,7 @@ DEPENDENCIES
   capybara (~> 3.33)
   dotenv-rails
   factory_bot_rails
+  faker
   foreman
   govuk_design_system_formbuilder
   listen (>= 3.0.5, < 3.3)

--- a/app/controllers/trainees/previous_education_controller.rb
+++ b/app/controllers/trainees/previous_education_controller.rb
@@ -1,0 +1,7 @@
+module Trainees
+  class PreviousEducationController < ApplicationController
+    def index
+      @trainee = Trainee.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -22,13 +22,40 @@ private
 
   def trainee_params
     params.require(:trainee)
-          .permit(:trainee_id,
-                  :first_names,
-                  :last_name,
-                  :date_of_birth,
-                  :gender,
-                  :nationality,
-                  :ethnicity,
-                  :disability)
+          .permit(trainee_all_params)
+  end
+
+  def trainee_all_params
+    trainee_personal_details_params + trainee_previous_education_params
+  end
+
+  def trainee_personal_details_params
+    %i[
+      trainee_id
+      first_names
+      last_name
+      date_of_birth
+      gender
+      nationality
+      ethnicity
+      disability
+    ]
+  end
+
+  def trainee_previous_education_params
+    %i[
+      a_level_1_subject
+      a_level_1_grade
+      a_level_2_subject
+      a_level_2_grade
+      a_level_3_subject
+      a_level_3_grade
+      degree_subject
+      degree_class
+      degree_institution
+      degree_type
+      ske
+      previous_qts
+    ]
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
-    <title>GOV.UK Rails Boilerplate</title>
+    <title>Register trainee teachers</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>
@@ -41,7 +41,7 @@
           <% end %>
         </div>
         <div class="govuk-header__content">
-          <%= link_to "GOV.UK Rails Boilerplate", "/", class: "govuk-header__link govuk-header__link--service-name" %>
+          <%= link_to "Register trainee teachers", "/", class: "govuk-header__link govuk-header__link--service-name" %>
           <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
           <nav>
             <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">

--- a/app/views/trainees/previous_education/index.html.erb
+++ b/app/views/trainees/previous_education/index.html.erb
@@ -1,0 +1,60 @@
+<h2 class="govuk-heading-l">Add previous education</h1>
+
+<%= form_with model: @trainee, data: { remote: false } do |f| %>
+  <h3 class="govuk-heading-m">A levels</h3>
+
+  <p class="govuk-body">
+    Or equivalent
+  </p>
+
+  <%= f.govuk_fieldset legend: { text: 'Subject and grade achieved' } do %>
+    <%= f.govuk_text_field :a_level_1_subject, label: { text: 'Subject' }, width: 'one-third' %>
+    <%= f.govuk_text_field :a_level_1_grade, label: { text: 'Grade' }, width: 2 %>
+
+    <%= f.govuk_text_field :a_level_2_subject, label: { text: 'Subject' }, width: 'one-third' %>
+    <%= f.govuk_text_field :a_level_2_grade, label: { text: 'Grade' }, width: 2 %>
+
+    <%= f.govuk_text_field :a_level_3_subject, label: { text: 'Subject' }, width: 'one-third' %>
+    <%= f.govuk_text_field :a_level_3_grade, label: { text: 'Grade' }, width: 2 %>
+  <% end %>
+
+  <%= f.govuk_fieldset legend: { text: 'Undergraduate degree' } do %>
+    <%= f.govuk_text_field :degree_subject, label: { text: 'Subject of undergraduate degree' }, width: 'two-thirds' %>
+
+    <% degree_classes = [OpenStruct.new(name: "1st"),
+                         OpenStruct.new(name: "2:1"),
+                         OpenStruct.new(name: "2:2"),
+                         OpenStruct.new(name: "3rd")] %>
+
+    <%= f.govuk_collection_radio_buttons :degree_class,
+        degree_classes,
+        :name,
+        :name,
+        legend: { text: 'Class of undergraduate degree' } %>
+
+    <%= f.govuk_text_field :degree_institution, label: { text: 'Undergraduate degree awarding institution' }, width: 'two-thirds' %>
+
+    <%= f.govuk_text_field :degree_type, label: { text: 'Degree type' }, hint_text: 'For example, BA, BSc, Masters, Ph or other(please specify)',  width: 'two-thirds' %>
+  <% end %>
+
+  <% skes = [OpenStruct.new(name: "Currently on SKE course"),
+             OpenStruct.new(name: "SKE not required"),
+             OpenStruct.new(name: "Completed SKE course")] %>
+
+  <%= f.govuk_collection_radio_buttons :ske,
+      skes,
+      :name,
+      :name,
+      legend: { text: 'Skill knowledge enhancement (SKE)' } %>
+
+  <% previous_qts_options = [OpenStruct.new(name: "No", value: false),
+                             OpenStruct.new(name: "Yes", value: true)] %>
+
+  <%= f.govuk_collection_radio_buttons :previous_qts,
+      previous_qts_options,
+      :value,
+      :name,
+      legend: { text: 'Previously gained QTS' } %>
+
+  <%= f.govuk_submit "Add previous education to training record" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :trainees, only: %i[show new create update] do
     member do
       get "personal-details", to: "trainees/personal_details#index"
+      get "previous-education", to: "trainees/previous_education#index"
     end
   end
 end

--- a/db/migrate/20200901113117_add_previous_education.rb
+++ b/db/migrate/20200901113117_add_previous_education.rb
@@ -1,0 +1,22 @@
+class AddPreviousEducation < ActiveRecord::Migration[6.0]
+  def change
+    change_table :trainees, bulk: true do |t|
+      t.column :a_level_1_subject, :text, null: true
+      t.column :a_level_1_grade, :text, null: true
+
+      t.column :a_level_2_subject, :text, null: true
+      t.column :a_level_2_grade, :text, null: true
+
+      t.column :a_level_3_subject, :text, null: true
+      t.column :a_level_3_grade, :text, null: true
+
+      t.column :degree_subject, :text, null: true
+      t.column :degree_class, :text, null: true
+      t.column :degree_institution, :text, null: true
+      t.column :degree_type, :text, null: true
+
+      t.column :ske, :text, null: true
+      t.column :previous_qts, :boolean, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_25_143103) do
+ActiveRecord::Schema.define(version: 2020_09_01_113117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,18 @@ ActiveRecord::Schema.define(version: 2020_08_25_143103) do
     t.text "disability"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "a_level_1_subject"
+    t.text "a_level_1_grade"
+    t.text "a_level_2_subject"
+    t.text "a_level_2_grade"
+    t.text "a_level_3_subject"
+    t.text "a_level_3_grade"
+    t.text "degree_subject"
+    t.text "degree_class"
+    t.text "degree_institution"
+    t.text "degree_type"
+    t.text "ske"
+    t.boolean "previous_qts"
   end
 
 end

--- a/spec/controllers/trainees/previous_education_controller_spec.rb
+++ b/spec/controllers/trainees/previous_education_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Trainees::PreviousEducationController do
+  describe "#index" do
+    let(:trainee) { build(:trainee) }
+    let(:id) { "1" }
+
+    before do
+      expect(Trainee).to receive(:find).with(id).and_return(trainee)
+      get :index, params: { id: id }
+    end
+
+    it "returns 200" do
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/controllers/trainees_controller_spec.rb
+++ b/spec/controllers/trainees_controller_spec.rb
@@ -49,28 +49,45 @@ RSpec.describe TraineesController do
 
   describe "#update" do
     let(:trainee) { create(:trainee) }
+    let(:new_trainee_attributes) { attributes_for(:trainee_for_form) }
+    let(:new_dob) do
+      Date.new(new_trainee_attributes[:"date_of_birth(1i)"].to_i,
+               new_trainee_attributes[:"date_of_birth(2i)"].to_i,
+               new_trainee_attributes[:"date_of_birth(3i)"].to_i)
+    end
 
     before do
       put :update, params: { id: trainee.id,
-                             trainee: { first_names: "Fred",
-                                        last_name: "Bloggs",
-                                        "date_of_birth(3i)": "19",
-                                        "date_of_birth(2i)": "7",
-                                        "date_of_birth(1i)": "1994",
-                                        gender: "Female",
-                                        nationality: "Scottish",
-                                        ethnicity: "French",
-                                        disability: "Dyslexic" } }
+                             trainee: new_trainee_attributes }
     end
 
     it "tests for change in record" do
-      expect(trainee.reload.first_names).to eql("Fred")
-      expect(trainee.last_name).to eql("Bloggs")
-      expect(trainee.date_of_birth).to eql(Date.new(1994, 7, 19))
-      expect(trainee.gender).to eql("Female")
-      expect(trainee.nationality).to eql("Scottish")
-      expect(trainee.ethnicity).to eql("French")
-      expect(trainee.disability).to eql("Dyslexic")
+      trainee.reload
+
+      expect(trainee.date_of_birth).to eql(new_dob)
+
+      %i[
+        first_names
+        last_name
+        gender
+        nationality
+        ethnicity
+        disability
+        a_level_1_subject
+        a_level_1_grade
+        a_level_2_subject
+        a_level_2_grade
+        a_level_3_subject
+        a_level_3_grade
+        degree_subject
+        degree_class
+        degree_institution
+        degree_type
+        ske
+        previous_qts
+      ].each do |field|
+        expect(trainee.public_send(field)).to eql(new_trainee_attributes[field])
+      end
     end
   end
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -1,21 +1,39 @@
 # rubocop:disable Style/SymbolProc
 FactoryBot.define do
-  factory :trainee do
-  end
-
-  factory :trainee_for_form, class: Trainee do
+  factory :abstract_trainee, class: Trainee do
     sequence :trainee_id do |n|
       n.to_s
     end
-    first_names { "Steve" }
-    last_name { "Smith" }
-    gender { "Male" }
-    add_attribute("date_of_birth(3i)") { "29" }
-    add_attribute("date_of_birth(2i)") { "4" }
-    add_attribute("date_of_birth(1i)") { "1999" }
-    nationality { "british" }
-    ethnicity { "british" }
-    disability { "none" }
+    first_names { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    gender { %w[Female Male Other].sample }
+
+    nationality { Faker::Nation.nationality }
+    ethnicity { Faker::Nation.nationality }
+    disability { %w[none something].sample }
+
+    a_level_1_subject { "Maths" }
+    a_level_1_grade { %w[A B C].sample }
+    a_level_2_subject { "Geography" }
+    a_level_2_grade { %w[A B C].sample }
+    a_level_3_subject { "Physics" }
+    a_level_3_grade { %w[A B C].sample }
+    degree_subject { "Software Engineering" }
+    degree_class { "2:1" }
+    degree_institution { Faker::University.name }
+    degree_type { "BSc" }
+    ske { "SKE not required" }
+    previous_qts { false }
+
+    factory :trainee do
+      date_of_birth { Faker::Date.birthday(min_age: 18, max_age: 65) }
+    end
+
+    factory :trainee_for_form do
+      add_attribute("date_of_birth(3i)") { Faker::Date.birthday(min_age: 18, max_age: 65).day.to_s }
+      add_attribute("date_of_birth(2i)") { Faker::Date.birthday(min_age: 18, max_age: 65).month.to_s }
+      add_attribute("date_of_birth(1i)") { Faker::Date.birthday(min_age: 18, max_age: 65).year.to_s }
+    end
   end
 end
 # rubocop:enable Style/SymbolProc


### PR DESCRIPTION
### Context

- https://trello.com/c/3CF50Pm6/25-add-previous-education-form
- Ability to add previous education data to trainee

### Changes proposed in this pull request

- Adds new page with form for previous education data entry
- Adds and uses faker in factories
- Adds migration for previous education

![image](https://user-images.githubusercontent.com/92580/91865292-24b84a00-ec69-11ea-9e97-25a2ecb365d5.png)

### Guidance to review

- Create or find an existing trainee
- Update their previous education info
- Look in database, values should reflect new values

View https://dfe-twd-rttd-pr-14.herokuapp.com/trainees/1/previous-education