### PR TITLE
rake task to run db:migrate only on first instance

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 yarn 1.22.4
 nodejs 12.18.3
+ruby 2.7.1

--- a/lib/tasks/cloudfoundry.rake
+++ b/lib/tasks/cloudfoundry.rake
@@ -1,0 +1,7 @@
+namespace :cf do
+  desc "Only run on the first application instance"
+  task :on_first_instance do # rubocop:disable Rails/RakeEnvironment
+    instance_index = JSON.parse(ENV["VCAP_APPLICATION"])["instance_index"] rescue nil
+    exit(0) unless instance_index.zero?
+  end
+end


### PR DESCRIPTION
### Context
rake task to help determine the app's instance number and run `db:migrate` only once during startup.

### Changes proposed in this pull request
rake task `cf:on_first_instance`

### Guidance to review

