### PR TITLE
[24] - Implement trainee contact details summary

### DIFF
--- a/app/presenters/trainee_contact_details.rb
+++ b/app/presenters/trainee_contact_details.rb
@@ -1,0 +1,40 @@
+class TraineeContactDetails
+  attr_reader :trainee
+
+  def initialize(trainee)
+    @trainee = trainee
+  end
+
+  def call
+    relevant_attributes.map { |k, v|
+      [I18n.t("presenters.TraineeContactDetails.attributes.#{k}"), v]
+    }.to_h
+  end
+
+private
+
+  def relevant_attributes
+    attrs = address_fields
+    attrs.merge(trainee.attributes.select { |k, _v| relevant_fields.include?(k) })
+  end
+
+  def address_fields
+    {
+      address: address_values,
+    }
+  end
+
+  def address_values
+    return "" if trainee.address_line_one.blank?
+
+    "#{trainee.address_line_one}, #{trainee.address_line_two}, #{trainee.town_city}, #{trainee.county}"
+  end
+
+  def relevant_fields
+    %w[
+      postcode
+      phone
+      email
+    ]
+  end
+end

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -8,6 +8,16 @@
   <%= render(SummaryTableComponent.new(content_hash: TraineePersonalDetails.new(@trainee).call)) %>
 </div>
 
+<h2 class="govuk-heading-l"><%= t('views.trainee_summary.contact_details.heading') %></h2>
+
+<p>
+  <%= link_to "Update", contact_details_trainee_path(@trainee), class: "govuk-link" %>
+</p>
+
+<div class="contact-details">
+  <%= render(SummaryTableComponent.new(content_hash: TraineeContactDetails.new(@trainee).call)) %>
+</div>
+
 <h2 class="govuk-heading-l">Previous education</h2>
 
 <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,10 +1,20 @@
 en:
   hello: Hello
+  views:
+    trainee_summary:
+      contact_details:
+        heading: "Contact Details"
   activerecord:
     attributes:
       trainee:
         trainee_id: "Trainee ID"
   presenters:
+    TraineeContactDetails:
+      attributes:
+        address: "Address"
+        postcode: "Postcode"
+        phone: "Phone number"
+        email: "Email"
     TraineePreviousEducation:
       attributes:
         first_a_level: "First A level subject and grade"

--- a/spec/components/summary_table_component_spec.rb
+++ b/spec/components/summary_table_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SummaryTableComponent, type: :component do
     end
   end
 
-  describe "formatted_attribute_id" do
+  describe "#formatted_attribute_id" do
     let(:content_hash) { { "Trainee ID" => "Alfred" } }
     let(:expected_key) { "trainee-id" }
 

--- a/spec/features/trainees/trainee_summary_spec.rb
+++ b/spec/features/trainees/trainee_summary_spec.rb
@@ -1,14 +1,37 @@
 require "rails_helper"
 
-RSpec.feature "Trainee summary page", type: :system do
-  let(:summary_page) { PageObjects::Trainees::SummaryPage.new }
-  let(:trainee) { create(:trainee) }
-
-  before do
-    summary_page.load(id: trainee.id)
+feature "Trainee summary page", type: :system do
+  scenario "displays the personal details" do
+    given_a_trainee_exists
+    when_i_visit_the_summary_page
+    then_i_can_see_the_personal_details
   end
 
-  scenario "displays the personal details" do
-    expect(summary_page.personal_details.trainee_id.text).to eq(trainee.trainee_id)
+  scenario "displays the contact details" do
+    given_a_trainee_exists
+    when_i_visit_the_summary_page
+    then_i_can_see_the_contact_details
+  end
+
+  def given_a_trainee_exists
+    @trainee = create(:trainee)
+  end
+
+  def when_i_visit_the_summary_page
+    @summary_page ||= PageObjects::Trainees::SummaryPage.new
+    @summary_page.load(id: @trainee.id)
+  end
+
+  def then_i_can_see_the_personal_details
+    expect(@summary_page.personal_details.trainee_id.text).to eq(@trainee.trainee_id)
+  end
+
+  def then_i_can_see_the_contact_details
+    expected_address = "#{@trainee.address_line_one}, #{@trainee.address_line_two}, #{@trainee.town_city}, #{@trainee.county}"
+
+    expect(@summary_page.contact_details.address.text).to eq(expected_address)
+    expect(@summary_page.contact_details.postcode.text).to eq(@trainee.postcode)
+    expect(@summary_page.contact_details.phone.text).to eq(@trainee.phone)
+    expect(@summary_page.contact_details.email.text).to eq(@trainee.email)
   end
 end

--- a/spec/presenters/trainee_contact_details_spec.rb
+++ b/spec/presenters/trainee_contact_details_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe TraineeContactDetails do
+  let(:trainee) { build(:trainee) }
+
+  subject { described_class.new(trainee) }
+
+  it "returns presented data" do
+    expect(subject.call).to eql({
+      "Address" => "#{trainee.address_line_one}, #{trainee.address_line_two}, #{trainee.town_city}, #{trainee.county}",
+      "Postcode" => trainee.postcode,
+      "Phone number" => trainee.phone,
+      "Email" => trainee.email,
+    })
+  end
+end

--- a/spec/support/page_objects/sections/contact_details.rb
+++ b/spec/support/page_objects/sections/contact_details.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class ContactDetails < PageObjects::Sections::Base
+      element :address, ".address > .govuk-summary-list__value"
+      element :postcode, ".postcode > .govuk-summary-list__value"
+      element :phone, ".phone-number > .govuk-summary-list__value"
+      element :email, ".email > .govuk-summary-list__value"
+    end
+  end
+end

--- a/spec/support/page_objects/sections/contact_details.rb
+++ b/spec/support/page_objects/sections/contact_details.rb
@@ -5,10 +5,10 @@ require_relative "base"
 module PageObjects
   module Sections
     class ContactDetails < PageObjects::Sections::Base
-      element :address, ".address > .govuk-summary-list__value"
-      element :postcode, ".postcode > .govuk-summary-list__value"
-      element :phone, ".phone-number > .govuk-summary-list__value"
-      element :email, ".email > .govuk-summary-list__value"
+      element :address, ".address .govuk-summary-list__value"
+      element :postcode, ".postcode .govuk-summary-list__value"
+      element :phone, ".phone-number .govuk-summary-list__value"
+      element :email, ".email .govuk-summary-list__value"
     end
   end
 end

--- a/spec/support/page_objects/trainees/summary_page.rb
+++ b/spec/support/page_objects/trainees/summary_page.rb
@@ -6,6 +6,7 @@ module PageObjects
       set_url "trainees/{/id}"
 
       section :personal_details, PageObjects::Sections::PersonalDetails, ".personal-details"
+      section :contact_details, PageObjects::Sections::ContactDetails, ".contact-details"
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/BG86E5mD/24-s-add-contact-details-summary

### Changes proposed in this pull request

- Implements the trainee contact details summary

<img width="1275" alt="Screenshot 2020-09-04 at 15 58 03" src="https://user-images.githubusercontent.com/616080/92253508-7fe77800-eec7-11ea-8469-3fbb488f71f9.png">

### Guidance to review

- Fire up localhost, load the trainee summary
- Add address details
- Assert address details are displayed in the summary

