### PR TITLE
[30] add course details summary

### DIFF
--- a/app/presenters/trainee_course_details.rb
+++ b/app/presenters/trainee_course_details.rb
@@ -1,0 +1,33 @@
+class TraineeCourseDetails
+  attr_reader :trainee
+
+  def initialize(trainee)
+    @trainee = trainee
+  end
+
+  def call
+    relevant_attributes.map { |k, v|
+      [Trainee.human_attribute_name(k), v]
+    }.to_h
+  end
+
+private
+
+  def relevant_attributes
+    trainee.attributes.select { |k, _v| relevant_fields.include?(k) }
+  end
+
+  def relevant_fields
+    %w[
+      course_title
+      course_phase
+      programme_start_date
+      programme_length
+      programme_end_date
+      allocation_subject
+      itt_subject
+      employing_school
+      placement_school
+    ]
+  end
+end

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -25,3 +25,13 @@
 </p>
 
 <%= render(SummaryTableComponent.new(content_hash: TraineePreviousEducation.new(@trainee).call)) %>
+
+<h2 class="govuk-heading-l">Course details</h2>
+
+<p>
+  <%= link_to "Update", course_details_trainee_path(@trainee), class: "govuk-link" %>
+</p>
+
+<div class="course-details">
+  <%= render(SummaryTableComponent.new(content_hash: TraineeCourseDetails.new(@trainee).call)) %>
+</div>

--- a/spec/features/edit_course_details_spec.rb
+++ b/spec/features/edit_course_details_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+feature "edit course details" do
+  scenario "edit with valid parameters" do
+    given_a_trainee_exists
+    when_i_visit_the_course_details_page
+    and_i_enter_valid_parameters
+    then_i_am_redirected_to_the_summary_page
+    and_the_updated_values_are_visible
+  end
+
+  def given_a_trainee_exists
+    trainee
+  end
+
+  def when_i_visit_the_course_details_page
+    course_details_page.load(id: trainee.id)
+  end
+
+  def and_i_enter_valid_parameters
+    course_details_page.course_title.set "Test Course"
+    course_details_page.course_phase.set "11-16"
+    set_date_fields("programme_start_date", "10/01/2021")
+    course_details_page.programme_length.set "1 year"
+    set_date_fields("programme_end_date", "10/01/2022")
+    course_details_page.allocation_subject.set "Maths"
+    course_details_page.itt_subject.set "Maths"
+    course_details_page.employing_school.set "Hillside College"
+    course_details_page.placement_school.set "Northwich Academy"
+    course_details_page.submit_button.click
+  end
+
+  def then_i_am_redirected_to_the_summary_page
+    expect(summary_page).to be_displayed(id: trainee.id)
+  end
+
+  def set_date_fields(field_prefix, date_string)
+    day, month, year = date_string.split("/")
+    course_details_page.send("#{field_prefix}_day").set day
+    course_details_page.send("#{field_prefix}_month").set month
+    course_details_page.send("#{field_prefix}_year").set year
+  end
+
+  def and_the_updated_values_are_visible
+    expect(summary_page.course_details.course_title.text).to eq("Test Course")
+  end
+
+  def course_details_page
+    @course_details_page ||= PageObjects::Trainees::CourseDetails.new
+  end
+
+  def summary_page
+    @summary_page ||= PageObjects::Trainees::SummaryPage.new
+  end
+
+  def trainee
+    @trainee ||= create(:trainee)
+  end
+end

--- a/spec/support/page_objects/sections/course_details.rb
+++ b/spec/support/page_objects/sections/course_details.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class CourseDetails < PageObjects::Sections::Base
+      element :course_title, ".course-title .govuk-summary-list__value"
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/summary_page.rb
+++ b/spec/support/page_objects/trainees/summary_page.rb
@@ -7,6 +7,7 @@ module PageObjects
 
       section :personal_details, PageObjects::Sections::PersonalDetails, ".personal-details"
       section :contact_details, PageObjects::Sections::ContactDetails, ".contact-details"
+      section :course_details, PageObjects::Sections::CourseDetails, ".course-details"
     end
   end
 end


### PR DESCRIPTION
### Context

Update to the summary page.

### Changes proposed in this pull request

* Add course details section to summary page
* Refactor edit course details feature spec and add expectation for
  summary

### Guidance to review

I've added an expectation to the edit course details feature spec rather than the summary page feature spec. 'Edit course details' seems more like 'the feature' than 'a summary page'. The expectation is only for one value at this point as that page will likely be redesigned next week.

![image](https://user-images.githubusercontent.com/5216/92263184-1de13f80-eed4-11ea-9942-23092aa2ed2b.png)


