### PR TITLE
Update trainee phone to phone_number

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -76,7 +76,7 @@ private
       town_city
       county
       postcode
-      phone
+      phone_number
       email
     ]
   end

--- a/app/presenters/trainee_contact_details.rb
+++ b/app/presenters/trainee_contact_details.rb
@@ -7,7 +7,7 @@ class TraineeContactDetails
 
   def call
     relevant_attributes.map { |k, v|
-      [I18n.t("presenters.TraineeContactDetails.attributes.#{k}"), v]
+      [Trainee.human_attribute_name(k), v]
     }.to_h
   end
 
@@ -33,7 +33,7 @@ private
   def relevant_fields
     %w[
       postcode
-      phone
+      phone_number
       email
     ]
   end

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -23,7 +23,7 @@
       label: { text: 'Postcode' } %>
   <% end %>
 
-  <%= f.govuk_phone_field :phone,
+  <%= f.govuk_phone_field :phone_number,
     width: 'two-thirds',
     label: { text: 'Phone number' },
     hint_text: "Enter a landline or mobile. For non-UK numbers, include the country code" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,12 +9,6 @@ en:
       trainee:
         trainee_id: "Trainee ID"
   presenters:
-    TraineeContactDetails:
-      attributes:
-        address: "Address"
-        postcode: "Postcode"
-        phone: "Phone number"
-        email: "Email"
     TraineePreviousEducation:
       attributes:
         first_a_level: "First A level subject and grade"

--- a/db/migrate/20200907121550_rename_trainees_phone_field.rb
+++ b/db/migrate/20200907121550_rename_trainees_phone_field.rb
@@ -1,0 +1,5 @@
+class RenameTraineesPhoneField < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :trainees, :phone, :phone_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_03_085102) do
+ActiveRecord::Schema.define(version: 2020_09_07_121550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,8 +43,11 @@ ActiveRecord::Schema.define(version: 2020_09_03_085102) do
     t.text "town_city"
     t.text "county"
     t.text "postcode"
-    t.text "phone"
+    t.text "phone_number"
     t.text "email"
+    t.date "start_date"
+    t.text "full_time_part_time"
+    t.boolean "teaching_scholars"
     t.text "course_title"
     t.text "course_phase"
     t.date "programme_start_date"
@@ -54,9 +57,6 @@ ActiveRecord::Schema.define(version: 2020_09_03_085102) do
     t.text "itt_subject"
     t.text "employing_school"
     t.text "placement_school"
-    t.date "start_date"
-    t.text "full_time_part_time"
-    t.boolean "teaching_scholars"
   end
 
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
     town_city { Faker::Address.city }
     county { Faker::Address.state }
     postcode { Faker::Address.postcode }
-    phone { [Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone].sample }
+    phone_number { [Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone].sample }
     email { "#{first_names}.#{last_name}@example.com" }
     start_date { Time.zone.now }
     full_time_part_time { %w[full_time part_time].sample }

--- a/spec/features/trainees/trainee_summary_spec.rb
+++ b/spec/features/trainees/trainee_summary_spec.rb
@@ -43,7 +43,7 @@ feature "Trainee summary page", type: :system do
 
     expect(@summary_page.contact_details.address.text).to eq(expected_address)
     expect(@summary_page.contact_details.postcode.text).to eq(@trainee.postcode)
-    expect(@summary_page.contact_details.phone.text).to eq(@trainee.phone)
+    expect(@summary_page.contact_details.phone_number.text).to eq(@trainee.phone_number)
     expect(@summary_page.contact_details.email.text).to eq(@trainee.email)
   end
 end

--- a/spec/presenters/trainee_contact_details_spec.rb
+++ b/spec/presenters/trainee_contact_details_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TraineeContactDetails do
     expect(subject.call).to eql({
       "Address" => "#{trainee.address_line_one}, #{trainee.address_line_two}, #{trainee.town_city}, #{trainee.county}",
       "Postcode" => trainee.postcode,
-      "Phone number" => trainee.phone,
+      "Phone number" => trainee.phone_number,
       "Email" => trainee.email,
     })
   end

--- a/spec/support/page_objects/sections/contact_details.rb
+++ b/spec/support/page_objects/sections/contact_details.rb
@@ -7,7 +7,7 @@ module PageObjects
     class ContactDetails < PageObjects::Sections::Base
       element :address, ".address .govuk-summary-list__value"
       element :postcode, ".postcode .govuk-summary-list__value"
-      element :phone, ".phone-number .govuk-summary-list__value"
+      element :phone_number, ".phone-number .govuk-summary-list__value"
       element :email, ".email .govuk-summary-list__value"
     end
   end


### PR DESCRIPTION
### Context

- Builds on the discussion from https://github.com/DFE-Digital/register-trainee-teacher-data/pull/26#discussion_r484273202

### Changes proposed in this pull request

- Rename trainee `phone` to `phone_number` and update relevant files

### Guidance to review

- Nothing significant to review locally other than the fact that the phone number field is displayed correctly on the summary page

