### PR TITLE
[91] Add ping/healthcheck endpoints

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -1,0 +1,50 @@
+require "sidekiq/api"
+
+class HeartbeatController < ActionController::API
+  def ping
+    render body: "PONG"
+  end
+
+  def healthcheck
+    checks = {
+      database: database_alive?,
+      redis: redis_alive?,
+      sidekiq_processes: sidekiq_processes_checks,
+    }
+
+    status = checks.values.all? ? :ok : :service_unavailable
+
+    render status: status,
+           json: {
+             checks: checks,
+           }
+  end
+
+private
+
+  def database_alive?
+    ActiveRecord::Base.connection.active?
+  rescue PG::ConnectionBad
+    false
+  end
+
+  def redis_alive?
+    Sidekiq.redis_info
+    true
+  rescue StandardError
+    false
+  end
+
+  def sidekiq_processes_checks
+    stats = Sidekiq::Stats.new
+    processes = Sidekiq::ProcessSet.new
+
+    # Iterate over each Sidekiq queue and ensure that there is a process
+    # running for it.
+    stats.queues.keys.all? do |queue|
+      processes.any? { |process| queue.in? process["queues"] }
+    end
+  rescue StandardError
+    false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ require_relative "routes/sidekiq_routes"
 Rails.application.routes.draw do
   extend SidekiqRoutes
 
+  get :ping, controller: :heartbeat
+  get :healthcheck, controller: :heartbeat
+
   get "/pages/:page", to: "pages#show"
 
   get "/404", to: "errors#not_found", via: :all

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -1,0 +1,113 @@
+require "rails_helper"
+
+describe "heartbeat requests" do
+  describe "GET /ping" do
+    it "returns PONG" do
+      get "/ping"
+
+      expect(response.body).to eq "PONG"
+    end
+  end
+
+  describe "GET /healthcheck" do
+    let(:stats)      { instance_double(Sidekiq::Stats) }
+    let(:process)    { instance_double(Sidekiq::Process) }
+    let(:queue_name) { "quest" }
+    let(:queues)     { { queue_name => 0 } }
+
+    before do
+      allow(Sidekiq::Stats).to receive(:new).and_return(stats)
+      allow(stats).to receive(:queues).and_return(queues)
+
+      allow(Sidekiq::ProcessSet).to receive(:new).and_return([process])
+      allow(process).to receive(:[]).with("queues").and_return([queue_name])
+
+      allow(ActiveRecord::Base.connection).to receive(:active?).and_return(true)
+      allow(Sidekiq).to receive(:redis_info).and_return({})
+    end
+
+    context "when everything is ok" do
+      it "returns HTTP success" do
+        get "/healthcheck"
+
+        expect(response.status).to eq(200)
+      end
+
+      it "returns JSON" do
+        get "/healthcheck"
+        expect(response.content_type).to eq("application/json")
+      end
+
+      it "returns the expected response report" do
+        get "/healthcheck"
+
+        expect(response.body).to eq({ checks: {
+          database: true,
+          redis: true,
+          sidekiq_processes: true,
+        } }.to_json)
+      end
+    end
+
+    context "there's no process for a queue" do
+      before do
+        allow(process).to receive(:[]).with("queues").and_return([])
+      end
+
+      it("returns 503") do
+        get "/healthcheck"
+
+        expect(response.status).to eq 503
+      end
+
+      it "sets the sidekiq queue to false" do
+        get "/healthcheck"
+
+        json_response = JSON.parse(response.body)
+
+        expect(json_response["checks"]["sidekiq_processes"]).to eq false
+      end
+    end
+
+    context "there's no Redis connection" do
+      before do
+        allow(Sidekiq).to receive(:redis_info).and_raise(Errno::ECONNREFUSED)
+      end
+
+      it("returns 503") do
+        get "/healthcheck"
+
+        expect(response.status).to eq 503
+      end
+
+      it "sets the sidekiq queue to false" do
+        get "/healthcheck"
+
+        json_response = JSON.parse(response.body)
+
+        expect(json_response["checks"]).to include("redis" => false)
+      end
+    end
+
+    context "there's no db connection" do
+      before do
+        allow(ActiveRecord::Base.connection)
+          .to receive(:active?).and_return(false)
+      end
+
+      it("returns 503") do
+        get "/healthcheck"
+
+        expect(response.status).to eq 503
+      end
+
+      it "sets the sidekiq queue to false" do
+        get "/healthcheck"
+
+        json_response = JSON.parse(response.body)
+
+        expect(json_response["checks"]).to include("database" => false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
- View the last commit in this PR and ignore the others which relate to another PR.

### Guidance to review
- Visit https://dfe-twd-rttd-pr-31.herokuapp.com/ping displays `PONG`
- Visit https://dfe-twd-rttd-pr-31.herokuapp.com/healthcheck - NB redis and sidekiq are returning false because the review app is on heroku and we haven't configured it yet.
- Testing it locally should return true for all of the checks
