### PR TITLE
[8] Implement basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,36 @@ or
 bundle exec scss-lint app/webpacker/styles
 ```
 
+## Secrets vs Settings
+
+Refer to the [the config gem](https://github.com/railsconfig/config#accessing-the-settings-object) to understand the `file based settings` loading order.
+
+To override file based via `Machine based env variables settings`
+
+```bash
+cat config/settings.yml
+file
+  based
+    settings
+      env1: 'foo'
+```
+
+```bash
+export SETTINGS__FILE__BASED__SETTINGS__ENV1="bar"
+```
+
+```ruby
+puts Settings.file.based.setting.env1
+
+bar
+```
+
+Refer to the [settings file](config/settings.yml) for all the settings required to run this app
+
+## Basic auth
+
+Basic auth is enabled in non-production and non-local environments. The credentials can be found in the Confluence pages.
+
 ## Deploying on GOV.UK PaaS
 
 ### Prerequisites

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,13 @@
 class ApplicationController < ActionController::Base
+  before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }
+
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+
+private
+
+  def enforce_basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      BasicAuthenticable.authenticate(username, password)
+    end
+  end
 end

--- a/app/controllers/concerns/basic_authenticable.rb
+++ b/app/controllers/concerns/basic_authenticable.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Enforces HTTP Basic Auth
+module BasicAuthenticable
+  class << self
+    def required?
+      Settings.basic_auth_required
+    end
+
+    def authenticate(username, password)
+      validate(username, password)
+    end
+
+    def validate(username, password)
+      utils.secure_compare(::Digest::SHA256.hexdigest(auth_username), ::Digest::SHA256.hexdigest(username)) &
+        utils.secure_compare(::Digest::SHA256.hexdigest(auth_password), ::Digest::SHA256.hexdigest(password))
+    end
+
+    def auth_username
+      @auth_username ||= Settings.basic_auth.username
+    end
+
+    def auth_password
+      @auth_password ||= Settings.basic_auth.password
+    end
+
+    def utils
+      ActiveSupport::SecurityUtils
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,1 @@
+basic_auth_required: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,1 @@
+basic_auth_required: false

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,0 +1,1 @@
+basic_auth_required: true

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,1 +1,0 @@
-basic_auth_required: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,1 @@
+basic_auth_required: false


### PR DESCRIPTION
### Context

- https://trello.com/c/HSd8hrXs/8-s-add-basic-auth-to-protect-the-app-in-deployed-envs

### Changes proposed in this pull request

- Implement basic auth singleton to protect against non-prod environments
- Bundle https://github.com/rubyconfig/config to manage app Settings
- Setup env specific yamls for handling settings per environment

### Guidance to review

- Set `basic_auth_required: true` in your local `yaml` settings file

Assert prompted with browser http auth prompt when visiting `localhost:3000/trainees/new`

