### PR TITLE
Setup view component previews

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,9 @@ module GovukRailsBoilerplate
 
     config.exceptions_app = routes
 
+    config.view_component.preview_paths = [Rails.root.join('spec/components/previews')]
+    config.view_component.show_previews = true
+
     config.middleware.use Rack::Deflater
   end
 end

--- a/spec/components/previews/summary_table_component_preview.rb
+++ b/spec/components/previews/summary_table_component_preview.rb
@@ -1,0 +1,9 @@
+class SummaryTableComponentPreview < ViewComponent::Preview
+  def default_state
+    render(SummaryTableComponent.new(content_hash: {
+      "First names": "Mike",
+      "Middle names": "Larson",
+      "Last name": "Doyle"
+    }))
+  end
+end


### PR DESCRIPTION
We will be building more components and we need a way to view components
and the various states which those components could be in.


### Context

### Changes proposed in this pull request
- Adds preview feature for view components

### Guidance to review

To review components just add `/rails/view_components` to the url in this case https://dfe-twd-rttd-pr-34.herokuapp.com/rails/view_components
