### PR TITLE
Remove autocorrect option from Rubocop lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       run: docker-compose exec -T web /bin/sh -c "bundle exec rails db:setup"
 
     - name: Run Ruby Linter
-      run: docker-compose exec -T web /bin/sh -c 'bundle exec rake lint:ruby'
+      run: docker-compose exec -T web /bin/sh -c 'bundle exec rubocop app config db lib spec Gemfile --format clang'
 
     - name: Run JavaScript Linter
       run: docker-compose exec -T web /bin/sh -c 'bundle exec rake lint:javascript'

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module GovukRailsBoilerplate
 
     config.exceptions_app = routes
 
-    config.view_component.preview_paths = [Rails.root.join('spec/components/previews')]
+    config.view_component.preview_paths = [Rails.root.join("spec/components/previews")]
     config.view_component.show_previews = true
 
     config.middleware.use Rack::Deflater

--- a/spec/components/previews/summary_table_component_preview.rb
+++ b/spec/components/previews/summary_table_component_preview.rb
@@ -3,7 +3,7 @@ class SummaryTableComponentPreview < ViewComponent::Preview
     render(SummaryTableComponent.new(content_hash: {
       "First names": "Mike",
       "Middle names": "Larson",
-      "Last name": "Doyle"
+      "Last name": "Doyle",
     }))
   end
 end

--- a/spec/features/trainees/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainees/creating_a_new_trainee_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Create trainee journey" do
     then_i_should_see_the_new_trainee_details
   end
 
-  private
+private
 
   def when_i_am_viewing_the_list_of_trainees
     @index_page ||= PageObjects::Trainees::IndexPage.new
@@ -23,12 +23,12 @@ RSpec.feature "Create trainee journey" do
   end
 
   def and_i_fill_in_train_id
-    @new_page.trainee_id_input.set('123')
+    @new_page.trainee_id_input.set("123")
   end
 
   def and_i_fill_in_first_and_last_name
-    @new_page.trainee_first_names_input.set('Tim')
-    @new_page.trainee_last_name_input.set('Smith')
+    @new_page.trainee_first_names_input.set("Tim")
+    @new_page.trainee_last_name_input.set("Smith")
   end
 
   def and_i_save_the_form


### PR DESCRIPTION
### Context

We’ve got a bit of an issue with the Rubocop lint task running in CI. It’s set to auto-correct but those corrected files won’t be committed so there’s a bit of a false positive in that it passes the CI but those offending files creep into `master`. 

### Changes proposed in this pull request

- Edit the CI build yaml file to explicitly fail Rubocop lint violations
- `./bin/rake` would still auto-correct locally
