### PR TITLE
Rename page objects

### DIFF
--- a/spec/features/edit_course_details_spec.rb
+++ b/spec/features/edit_course_details_spec.rb
@@ -50,7 +50,7 @@ feature "edit course details" do
   end
 
   def summary_page
-    @summary_page ||= PageObjects::Trainees::SummaryPage.new
+    @summary_page ||= PageObjects::Trainees::Summary.new
   end
 
   def trainee

--- a/spec/features/trainees/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainees/creating_a_new_trainee_spec.rb
@@ -13,12 +13,12 @@ RSpec.feature "Create trainee journey" do
 private
 
   def when_i_am_viewing_the_list_of_trainees
-    @index_page ||= PageObjects::Trainees::IndexPage.new
+    @index_page ||= PageObjects::Trainees::Index.new
     @index_page.load
   end
 
   def and_i_click_on_add_data_button
-    @new_page ||= PageObjects::Trainees::NewPage.new
+    @new_page ||= PageObjects::Trainees::New.new
     @index_page.add_data_link.click
   end
 
@@ -32,7 +32,7 @@ private
   end
 
   def and_i_save_the_form
-    @show_page ||= PageObjects::Trainees::ShowPage.new
+    @show_page ||= PageObjects::Trainees::Show.new
     @new_page.continue_button.click
   end
 

--- a/spec/features/trainees/edit_course_details_spec.rb
+++ b/spec/features/trainees/edit_course_details_spec.rb
@@ -45,7 +45,7 @@ feature "edit course details" do
   end
 
   def summary_page
-    @summary_page ||= PageObjects::Trainees::SummaryPage.new
+    @summary_page ||= PageObjects::Trainees::Summary.new
   end
 
   def trainee

--- a/spec/features/trainees/trainee_summary_spec.rb
+++ b/spec/features/trainees/trainee_summary_spec.rb
@@ -24,7 +24,7 @@ feature "Trainee summary page", type: :system do
   end
 
   def when_i_visit_the_summary_page
-    @summary_page ||= PageObjects::Trainees::SummaryPage.new
+    @summary_page ||= PageObjects::Trainees::Summary.new
     @summary_page.load(id: @trainee.id)
   end
 

--- a/spec/features/trainees/viewing_an_existing_trainee.rb
+++ b/spec/features/trainees/viewing_an_existing_trainee.rb
@@ -13,7 +13,7 @@ feature "View trainees", type: :feature do
   end
 
   def when_i_view_the_trainee_index_page
-    @index_page ||= PageObjects::Trainees::IndexPage.new
+    @index_page ||= PageObjects::Trainees::Index.new
     @index_page.load
   end
 
@@ -22,7 +22,7 @@ feature "View trainees", type: :feature do
   end
 
   def then_i_should_see_the_trainee_details
-    @show_page ||= PageObjects::Trainees::ShowPage.new
+    @show_page ||= PageObjects::Trainees::Show.new
     expect(@show_page).to be_displayed(id: @trainee.id)
   end
 end

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "view pages", type: :system do
-  let(:home_page) { PageObjects::HomePage.new }
+  let(:home_page) { PageObjects::Home.new }
 
   before do
     home_page.load

--- a/spec/support/page_objects/base.rb
+++ b/spec/support/page_objects/base.rb
@@ -1,0 +1,3 @@
+module PageObjects
+  class Base < SitePrism::Page; end
+end

--- a/spec/support/page_objects/base_page.rb
+++ b/spec/support/page_objects/base_page.rb
@@ -1,4 +1,0 @@
-module PageObjects
-  class BasePage < SitePrism::Page
-  end
-end

--- a/spec/support/page_objects/home.rb
+++ b/spec/support/page_objects/home.rb
@@ -1,7 +1,7 @@
 require_relative "sections/home_hero"
 
 module PageObjects
-  class HomePage < PageObjects::BasePage
+  class Home < PageObjects::Base
     set_url "/pages/home"
 
     section :hero, PageObjects::Sections::HomeHero, ".hero"

--- a/spec/support/page_objects/trainees/course_details.rb
+++ b/spec/support/page_objects/trainees/course_details.rb
@@ -1,6 +1,6 @@
 module PageObjects
   module Trainees
-    class CourseDetails < PageObjects::BasePage
+    class CourseDetails < PageObjects::Base
       set_url "/trainees/{id}/course-details"
       element :submit_button, "input[name='commit']"
       element :course_title, "#trainee-course-title-field"

--- a/spec/support/page_objects/trainees/create.rb
+++ b/spec/support/page_objects/trainees/create.rb
@@ -1,6 +1,6 @@
 module PageObjects
   module Trainees
-    class CreatePage < PageObjects::BasePage
+    class Create < PageObjects::Base
       set_url "/trainees/new"
 
       element :trainee_id_field, "#trainee-trainee-id-field"

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -1,6 +1,6 @@
 module PageObjects
   module Trainees
-    class IndexPage < PageObjects::BasePage
+    class Index < PageObjects::Base
       set_url "/trainees"
 
       element :page_title, ".govuk-heading-xl"

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -1,6 +1,6 @@
 module PageObjects
   module Trainees
-    class NewPage < PageObjects::BasePage
+    class New < PageObjects::Base
       set_url "/trainees/new"
 
       element :page_title, ".govuk-heading-xl"

--- a/spec/support/page_objects/trainees/show.rb
+++ b/spec/support/page_objects/trainees/show.rb
@@ -1,6 +1,6 @@
 module PageObjects
   module Trainees
-    class ShowPage < PageObjects::BasePage
+    class Show < PageObjects::Base
       set_url "/trainees/{id}"
     end
   end

--- a/spec/support/page_objects/trainees/summary.rb
+++ b/spec/support/page_objects/trainees/summary.rb
@@ -2,7 +2,7 @@ require_relative "../sections/personal_details"
 
 module PageObjects
   module Trainees
-    class SummaryPage < PageObjects::BasePage
+    class Summary < PageObjects::Base
       set_url "/trainees/{id}"
 
       section :personal_details, PageObjects::Sections::PersonalDetails, ".personal-details"

--- a/spec/support/page_objects/trainees/training_details.rb
+++ b/spec/support/page_objects/trainees/training_details.rb
@@ -1,6 +1,6 @@
 module PageObjects
   module Trainees
-    class TrainingDetails < PageObjects::BasePage
+    class TrainingDetails < PageObjects::Base
       set_url "/trainees/{id}/training-details"
       element :submit_button, "input[name='commit']"
       element :start_date_day, "#trainee_start_date_3i"


### PR DESCRIPTION
### Context

The 'Page' suffix is redundant e.g. `PageObjects::ShowPage`

### Changes proposed in this pull request

Remove it -> e.g. `PageObjects::Show`.
