### PR TITLE
[116] - Cache the dttp access token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*
+/{}/*
 
 # Ignore uploaded files in development
 /storage/*

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,7 +5,6 @@ Rails.application.configure do
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
-
   # Do not eager load code on boot.
   config.eager_load = false
 
@@ -18,7 +17,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
+    config.cache_store = :file_store
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}",
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :file_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/spec/services/dttp/access_token_service_spec.rb
+++ b/spec/services/dttp/access_token_service_spec.rb
@@ -40,6 +40,18 @@ module Dttp
       it "returns the access token" do
         expect(described_class.call).to eq("token")
       end
+
+      context "with cache" do
+        before do
+          allow(Rails.cache).to receive(:fetch).and_return("token")
+        end
+
+        it "caches the access token after the initial request" do
+          expect(described_class::AuthenticationClient).to receive(:post).never
+
+          described_class.call
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/a8iszbjM/116-m-add-token-cacheing-to-dttpaccesstokenservice

### Changes proposed in this pull request

- Activate `:file_store` as the cache store for dev and prod
- Wrap the network request in a `Rails.cache` so it's only fired if there's a cache miss.  

### Guidance to review

- Run `bundle exec {rails|rake} dev:cache` locally to enable caching in developmnent. This will create a file `tmp/caching-dev.txt` which Rails uses to toggle caching on/off for development.
- Load up a rails console and run `Dttp::AccessTokenService.call` (make sure you've filled out the connection settings in your yaml) and you should get back a token. Fire the command again and it should return the same token

Make sure you run `bundle exec {rails|rake} dev:cache` to turn off the dev caching locally when finished. I've tested the expiry when using `:file_store`. A binary file is created and used to update/reset the cache based on the time set with `expire_in`. 

Depends on https://github.com/DFE-Digital/register-trainee-teacher-data/pull/43
