### PR TITLE
[137] Add trainee presenter for dttp

### DIFF
--- a/app/controllers/trn_submissions_controller.rb
+++ b/app/controllers/trn_submissions_controller.rb
@@ -10,6 +10,8 @@ class TrnSubmissionsController < ApplicationController
 private
 
   def trainee
-    @trainee ||= Trainee.find(params[:trainee_id])
+    @trainee ||= Trainee.find(params[:trainee_id]).then do |trainee|
+      Dttp::TraineePresenter.new(trainee: trainee)
+    end
   end
 end

--- a/app/presenters/dttp/trainee_presenter.rb
+++ b/app/presenters/dttp/trainee_presenter.rb
@@ -1,0 +1,33 @@
+module Dttp
+  class TraineePresenter
+    attr_reader :trainee
+
+    delegate_missing_to :trainee
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def to_dttp_params
+      {
+        "firstname" => trainee.first_names,
+        "lastname" => trainee.last_name,
+        "contactid" => trainee.dttp_id,
+        "address1_line1" => trainee.address_line_one,
+        "address1_line2" => trainee.address_line_two,
+        "address1_line3" => trainee.town_city,
+        "address1_postalcode" => trainee.postcode,
+        "birthdate" => formatted_dob,
+        "emailaddress1" => trainee.email,
+        "gendercode" => trainee.gender,
+        "mobilephone" => trainee.phone_number,
+      }
+    end
+
+  private
+
+    def formatted_dob
+      trainee.date_of_birth.strftime("%d/%m/%Y")
+    end
+  end
+end

--- a/app/services/dttp/contact_service/create.rb
+++ b/app/services/dttp/contact_service/create.rb
@@ -12,7 +12,7 @@ module Dttp
       end
 
       def call
-        response = Client.post(endpoint_path, { body: body,
+        response = Client.post(endpoint_path, { body: trainee.to_dttp_params.as_json,
                                                 headers: headers })
 
         trainee.update!(dttp_id: parse_contactid(response))
@@ -24,8 +24,6 @@ module Dttp
 
       attr_reader :trainee
 
-      delegate :first_names, :last_name, :dttp_id, to: :trainee
-
       def auth_token
         AccessTokenService.call
       end
@@ -35,13 +33,6 @@ module Dttp
           "Accept" => "application/json",
           "Content-Type" => "application/json;odata.metadata=minimal",
           "Authorization" => "Bearer #{auth_token}",
-        }
-      end
-
-      def body
-        {
-          "firstname" => first_names,
-          "lastname" => last_name,
         }
       end
 

--- a/spec/controllers/trn_submissions_controller_spec.rb
+++ b/spec/controllers/trn_submissions_controller_spec.rb
@@ -3,10 +3,13 @@ require "rails_helper"
 describe TrnSubmissionsController do
   describe "#create" do
     let(:trainee_id) { "10" }
+    let(:trainee_data) { { some: "data" } }
+    let(:decorated_trainee) { instance_double(Dttp::TraineePresenter) }
 
-    it "passes the trainee to the create service" do
+    it "passes the decorated trainee to the create service" do
       allow(Trainee).to receive(:find).with(trainee_id).and_return(trainee = instance_double(Trainee))
-      expect(Dttp::ContactService::Create).to receive(:call).with(trainee: trainee)
+      expect(Dttp::TraineePresenter).to receive(:new).with(trainee: trainee).and_return(decorated_trainee)
+      expect(Dttp::ContactService::Create).to receive(:call).with(trainee: decorated_trainee)
 
       post :create, params: { trainee_id: trainee_id }
     end

--- a/spec/presenters/dttp/trainee_presenter_spec.rb
+++ b/spec/presenters/dttp/trainee_presenter_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+module Dttp
+  describe TraineePresenter do
+    let(:trainee) { build(:trainee) }
+
+    subject { described_class.new(trainee: trainee) }
+
+    describe "#to_dttp_params" do
+      it "returns a hash formatted for a DTTP contact creation" do
+        expect(subject.to_dttp_params).to eql({
+          "firstname" => trainee.first_names,
+          "lastname" => trainee.last_name,
+          "contactid" => trainee.dttp_id,
+          "address1_line1" => trainee.address_line_one,
+          "address1_line2" => trainee.address_line_two,
+          "address1_line3" => trainee.town_city,
+          "address1_postalcode" => trainee.postcode,
+          "birthdate" => trainee.date_of_birth.strftime("%d/%m/%Y"),
+          "emailaddress1" => trainee.email,
+          "gendercode" => trainee.gender,
+          "mobilephone" => trainee.phone_number,
+        })
+      end
+    end
+  end
+end

--- a/spec/services/dttp/contact_service/create_spec.rb
+++ b/spec/services/dttp/contact_service/create_spec.rb
@@ -3,10 +3,7 @@ require "rails_helper"
 module Dttp
   module ContactService
     describe Create do
-      let(:trainee) do
-        instance_double(Trainee, id: 1, first_names: "Dave", last_name: "Davids", dttp_id: "uuid-id")
-      end
-
+      let(:trainee) { TraineePresenter.new(trainee: build(:trainee)) }
       let(:access_token) { "token" }
       let(:endpoint_path) { "/contacts" }
       let(:contactid) { "60f77a42-5f0e-e611-80e0-00155da84c03" }
@@ -26,16 +23,9 @@ module Dttp
 
       describe ".call" do
         it "sends the payload to dttp" do
-          # TODO: add a presenter to handle the values for the payload and maybe pass that in instead
-
-          body = {
-            "firstname" => trainee.first_names,
-            "lastname" => trainee.last_name,
-          }
-
           expect(Client).to receive(:post).with(
             endpoint_path,
-            hash_including(body: body),
+            hash_including(body: trainee.to_dttp_params.as_json),
           ).and_return(response)
 
           described_class.call(trainee: trainee)


### PR DESCRIPTION
### Context

- https://trello.com/c/S6xNozZ5/137-m-add-trainee-presenter-for-dttp

### Changes proposed in this pull request

- Replaces the `trainee` active_record model passed into `ContactService::Create` with a presented version
- Handles all currently stored attributes on the Contact entity minus the look up ones.

I've referenced the RTTD - New Data Standard v1.1 but the following fields (which we currently have in the schema) are not added to the presenter as they're look up fields:

- `disability` - no matching d365 field at the moment
- `nationality`
- `ethinicity`

### Guidance to review

- Fire up a  rails console
- Run the following `Dttp::ContactService::Create.call(trainee: data)` where `data` is the result of `Dttp::TraineePresenter.new(trainee: {trainee_object})`
- Assert the payload is sent correctly

Depends on https://github.com/DFE-Digital/register-trainee-teacher-data/pull/43
