### PR TITLE
Remove view_component gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,8 +41,6 @@ gem "request_store", "~> 1.5"
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 
-gem "view_component"
-
 # Background job processor
 gem "sidekiq", "~> 6.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,7 +416,6 @@ DEPENDENCIES
   spring-commands-rspec (~> 1.0)
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
-  view_component
   web-console (>= 3.3.0)
   webdrivers (~> 4.4)
   webmock


### PR DESCRIPTION
This gem is already used and imported by `govuk-components` as a dependency

### Context

### Changes proposed in this pull request

### Guidance to review

