### PR TITLE
[165] Build personal details form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,7 @@ group :test do
   gem "cuprite", "~> 0.11"
   gem "webdrivers", "~> 4.4"
 
+  gem "shoulda-matchers", "~> 4.4"
   # Code coverage reporter
   gem "simplecov", "~> 0.19.0", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,6 +312,8 @@ GEM
     semantic_range (2.3.0)
     sentry-raven (3.0.2)
       faraday (>= 1.0)
+    shoulda-matchers (4.4.1)
+      activesupport (>= 4.2.0)
     sidekiq (6.1.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
@@ -409,6 +411,7 @@ DEPENDENCIES
   rubocop-govuk
   scss_lint-govuk
   sentry-raven
+  shoulda-matchers (~> 4.4)
   sidekiq (~> 6.1)
   simplecov (~> 0.19.0)
   site_prism (~> 3.4)

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -2,6 +2,7 @@ module Trainees
   class PersonalDetailsController < ApplicationController
     def edit
       @trainee = Trainee.find(params[:id])
+      @nationalities = Nationality.where(name: %w[british irish other])
     end
   end
 end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -26,7 +26,7 @@ private
 
   def trainee_params
     params.require(:trainee)
-      .permit(trainee_all_params)
+      .permit(trainee_all_params, nationality_ids: [])
   end
 
   def trainee_all_params
@@ -47,7 +47,6 @@ private
       last_name
       date_of_birth
       gender
-      nationality
       ethnicity
       disability
     ]

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -43,6 +43,7 @@ private
     %i[
       trainee_id
       first_names
+      middle_names
       last_name
       date_of_birth
       gender

--- a/app/helpers/nationalities_helper.rb
+++ b/app/helpers/nationalities_helper.rb
@@ -1,0 +1,15 @@
+module NationalitiesHelper
+  def format_default_nationalities(nationalities)
+    formatted_nationalities = []
+
+    nationalities.each do |nationality|
+      formatted_nationalities << OpenStruct.new(
+        id: nationality.id,
+        name: nationality.name.titleize,
+        description: I18n.t("views.default_nationalities.#{nationality.name}.description"),
+      )
+    end
+
+    formatted_nationalities
+  end
+end

--- a/app/models/nationalisation.rb
+++ b/app/models/nationalisation.rb
@@ -1,0 +1,4 @@
+class Nationalisation < ApplicationRecord
+  belongs_to :nationality
+  belongs_to :trainee
+end

--- a/app/models/nationality.rb
+++ b/app/models/nationality.rb
@@ -1,0 +1,4 @@
+class Nationality < ApplicationRecord
+  has_many :nationalisations, inverse_of: :nationality
+  has_many :trainees, through: :nationalisations
+end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -1,4 +1,7 @@
 class Trainee < ApplicationRecord
+  has_many :nationalisations, dependent: :destroy, inverse_of: :trainee
+  has_many :nationalities, through: :nationalisations
+
   def dttp_id=(value)
     raise LockedAttributeError, "dttp_id update failed for trainee ID: #{id}, with value: #{value}" if dttp_id.present?
 

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -1,25 +1,49 @@
-<h2 class="govuk-heading-l">Personal details</h2>
-
-<%= form_with model: @trainee, local: true do |f| %>
-  <%= f.govuk_text_field :trainee_id, label: { text: 'Trainee ID' }, width: 'one-quarter' %>
-
-  <%= f.govuk_text_field :first_names, label: { text: 'First names' }, hint: {text: 'Or given names'}, width: 'three-quarters' %>
-
-  <%= f.govuk_text_field :last_name, label: { text: 'Last name' }, hint: {text: 'Or family name'}, width: 'three-quarters' %>
-
-  <% genders = [OpenStruct.new(id: 1, name: 'Male'), OpenStruct.new(id: 2, name: 'Female'), OpenStruct.new(id: 3, name: 'Other')]%>
-  <%= f.govuk_collection_radio_buttons :gender, genders, :id, :name, legend: { text: 'Gender' } %>
-
-  <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: 'Date of birth' }, hint: {text: 'For example, 31 3 1980'} %>
-
-  <% nationalities = [OpenStruct.new(id: 1, name: '1'), OpenStruct.new(id: 2, name: '2'), OpenStruct.new(id: 3, name: '3')] %>
-  <%= f.govuk_collection_select :nationality, nationalities, :id, :name, label: { text: "Nationality" } %>
-
-  <% ethnicities = [OpenStruct.new(id: 1, name: '4'), OpenStruct.new(id: 2, name: '5'), OpenStruct.new(id: 3, name: '6')] %>
-  <%= f.govuk_collection_select :ethnicity, ethnicities, :id, :name, label: { text: "Ethnicity" } %>
-
-  <% disabilities = [OpenStruct.new(id: 1, name: '7'), OpenStruct.new(id: 2, name: '8'), OpenStruct.new(id: 3, name: '9')] %>
-  <%= f.govuk_collection_select :disability, disabilities, :id, :name, label: { text: "Disability" } %>
-
-  <%= f.govuk_submit %>
+<%= content_for(:breadcrumbs) do %>
+  <%= render_component GovukComponent::BackLink.new(
+    text: 'Back',
+    href: trainee_path(@trainee)
+  ) %>
 <% end %>
+
+<h2 class="govuk-heading-l">Trainee personal details</h2>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: @trainee, local: true do |f| %>
+      <%= f.govuk_text_field :first_names, label: { text: 'First names', size: 's' }, hint: { text: 'Or given names' }, width: 'three-quarters' %>
+
+      <%= f.govuk_text_field :middle_names, label: { text: 'Middle names', size: 's' }, width: 'three-quarters' %>
+
+      <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 's' }, width: 'three-quarters' %>
+
+      <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: 'Date of birth', size: 's' }, hint: { text: 'For example, 31 3 1980' } %>
+
+      <% genders = [OpenStruct.new(id: 1, name: 'Male'), OpenStruct.new(id: 2, name: 'Female'), OpenStruct.new(id: 3, name: 'Other')]%>
+      <%= f.govuk_collection_radio_buttons :gender, genders, :id, :name, legend: { text: 'Gender', size: 's' } %>
+
+      <% 
+        nationalities = [
+          OpenStruct.new(
+              id: 1,
+              name: 'British',
+              description: 'including English, Scottish, Welsh or from Northern Ireland '
+            ),
+            OpenStruct.new(
+              id: 2,
+              name: 'Irish',
+              description: 'including from Northern Ireland '
+            ),
+            OpenStruct.new(
+              id: 2,
+              name: 'Other'
+            )
+        ] 
+      %>
+      <%= f.govuk_collection_check_boxes :nationality, nationalities, :id, :name, :description, legend: { text: "Nationality", size: 's' }, hint: { text: 'Select all that apply' } %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>
+
+<p class="govuk-body"><%= govuk_link_to("Cancel", trainee_path(@trainee)) %></p>

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -19,27 +19,16 @@
       <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: 'Date of birth', size: 's' }, hint: { text: 'For example, 31 3 1980' } %>
 
       <% genders = [OpenStruct.new(id: 1, name: 'Male'), OpenStruct.new(id: 2, name: 'Female'), OpenStruct.new(id: 3, name: 'Other')]%>
-      <%= f.govuk_collection_radio_buttons :gender, genders, :id, :name, legend: { text: 'Gender', size: 's' } %>
+      <%= f.govuk_collection_radio_buttons :gender, genders, :id, :name, legend: { text: 'Gender', size: 's' }, classes: "gender" %>
 
-      <% 
-        nationalities = [
-          OpenStruct.new(
-              id: 1,
-              name: 'British',
-              description: 'including English, Scottish, Welsh or from Northern Ireland '
-            ),
-            OpenStruct.new(
-              id: 2,
-              name: 'Irish',
-              description: 'including from Northern Ireland '
-            ),
-            OpenStruct.new(
-              id: 2,
-              name: 'Other'
-            )
-        ] 
-      %>
-      <%= f.govuk_collection_check_boxes :nationality, nationalities, :id, :name, :description, legend: { text: "Nationality", size: 's' }, hint: { text: 'Select all that apply' } %>
+      <%= f.govuk_collection_check_boxes :nationality_ids, 
+          format_default_nationalities(@nationalities), 
+          :id, 
+          :name, 
+          :description, 
+          legend: { text: "Nationality", size: 's' }, 
+          hint: { text: 'Select all that apply' },
+          classes: "nationality" %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -54,6 +54,6 @@ private
   end
 end
 
-unless Rails.env.development?
+unless Rails.env.development? || Rails.env.test?
   SemanticLogger.add_appender(io: STDOUT, level: :info, formatter: CustomLogFormatter.new)
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,13 @@ en:
     trainee_summary:
       contact_details:
         heading: "Contact Details"
+    default_nationalities:
+      british:
+        description: including English, Scottish, Welsh or from Northern Ireland
+      irish: 
+        description: including from Northern Ireland 
+      other:
+        description: ""
   activerecord:
     attributes:
       trainee:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,3 +9,228 @@ dttp:
 # Used to add feature flags in the app to control access to certain features.
 features:
   home_text: false
+
+nationalities:
+  - afghan
+  - albanian
+  - algerian
+  - american
+  - andorran
+  - angolan
+  - anguillan
+  - argentine
+  - armenian
+  - australian
+  - austrian
+  - azerbaijani
+  - bahamian
+  - bahraini
+  - bangladeshi
+  - barbadian
+  - belarusian
+  - belgian
+  - belizean
+  - beninese
+  - bermudian
+  - bhutanese
+  - bolivian
+  - botswanan
+  - brazilian
+  - british
+  - british virgin islander
+  - bruneian
+  - bulgarian
+  - burkinan
+  - burmese
+  - burundian
+  - cambodian
+  - cameroonian
+  - canadian
+  - cape verdean
+  - cayman islander
+  - central african
+  - chadian
+  - chilean
+  - chinese
+  - citizen of antigua and barbuda
+  - citizen of bosnia and herzegovina
+  - citizen of guinea-bissau
+  - citizen of kiribati
+  - citizen of seychelles
+  - citizen of the dominican republic
+  - citizen of vanuatu
+  - colombian
+  - comoran
+  - congolese (congo)
+  - congolese (drc)
+  - cook islander
+  - costa rican
+  - croatian
+  - cuban
+  - cymraes
+  - cymro
+  - cypriot
+  - czech
+  - danish
+  - djiboutian
+  - dominican
+  - dutch
+  - east timorese
+  - ecuadorean
+  - egyptian
+  - emirati
+  - equatorial guinean
+  - eritrean
+  - estonian
+  - ethiopian
+  - faroese
+  - fijian
+  - filipino
+  - finnish
+  - french
+  - gabonese
+  - gambian
+  - georgian
+  - german
+  - ghanaian
+  - gibraltarian
+  - greek
+  - greenlandic
+  - grenadian
+  - guamanian
+  - guatemalan
+  - guinean
+  - guyanese
+  - haitian
+  - honduran
+  - hong konger
+  - hungarian
+  - icelandic
+  - indian
+  - indonesian
+  - iranian
+  - iraqi
+  - irish
+  - israeli
+  - italian
+  - ivorian
+  - jamaican
+  - japanese
+  - jordanian
+  - kazakh
+  - kenyan
+  - kittitian
+  - kosovan
+  - kuwaiti
+  - kyrgyz
+  - lao
+  - latvian
+  - lebanese
+  - liberian
+  - libyan
+  - liechtenstein citizen
+  - lithuanian
+  - luxembourger
+  - macanese
+  - macedonian
+  - malagasy
+  - malawian
+  - malaysian
+  - maldivian
+  - malian
+  - maltese
+  - marshallese
+  - martiniquais
+  - mauritanian
+  - mauritian
+  - mexican
+  - micronesian
+  - moldovan
+  - monegasque
+  - mongolian
+  - montenegrin
+  - montserratian
+  - moroccan
+  - mosotho
+  - mozambican
+  - namibian
+  - nauruan
+  - nepalese
+  - new zealander
+  - nicaraguan
+  - nigerian
+  - nigerien
+  - niuean
+  - north korean
+  - norwegian
+  - omani
+  - other
+  - pakistani
+  - palauan
+  - palestinian
+  - panamanian
+  - papua new guinean
+  - paraguayan
+  - peruvian
+  - pitcairn islander
+  - polish
+  - portuguese
+  - prydeinig
+  - puerto rican
+  - qatari
+  - romanian
+  - russian
+  - rwandan
+  - salvadorean
+  - sammarinese
+  - samoan
+  - sao tomean
+  - saudi arabian
+  - senegalese
+  - serbian
+  - sierra leonean
+  - singaporean
+  - slovak
+  - slovenian
+  - solomon islander
+  - somali
+  - south african
+  - south korean
+  - south sudanese
+  - spanish
+  - sri lankan
+  - st helenian
+  - st lucian
+  - stateless
+  - sudanese
+  - surinamese
+  - swazi
+  - swedish
+  - swiss
+  - syrian
+  - taiwanese
+  - tajik
+  - tanzanian
+  - thai
+  - togolese
+  - tongan
+  - trinidadian
+  - tristanian
+  - tunisian
+  - turkish
+  - turkmen
+  - turks and caicos islander
+  - tuvaluan
+  - ugandan
+  - ukrainian
+  - uruguayan
+  - uzbek
+  - vatican citizen
+  - venezuelan
+  - vietnamese
+  - vincentian
+  - wallisian
+  - yemeni
+  - zambian
+  - zimbabwean
+

--- a/db/migrate/20200929154128_add_middle_names_to_trainees.rb
+++ b/db/migrate/20200929154128_add_middle_names_to_trainees.rb
@@ -1,0 +1,5 @@
+class AddMiddleNamesToTrainees < ActiveRecord::Migration[6.0]
+  def change
+    add_column :trainees, :middle_names, :text
+  end
+end

--- a/db/migrate/20200929163820_create_nationalities.rb
+++ b/db/migrate/20200929163820_create_nationalities.rb
@@ -1,0 +1,8 @@
+class CreateNationalities < ActiveRecord::Migration[6.0]
+  def change
+    create_table :nationalities do |t|
+      t.string :name, null: false, index: { unique: true }
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200929163827_create_nationalisations.rb
+++ b/db/migrate/20200929163827_create_nationalisations.rb
@@ -1,0 +1,9 @@
+class CreateNationalisations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :nationalisations do |t|
+      t.references :trainee, index: true, null: false, foreign_key: { to_table: :trainees }
+      t.references :nationality, index: true, null: false, foreign_key: { to_table: :nationalities }
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200930125009_remove_nationality_from_trainees.rb
+++ b/db/migrate/20200930125009_remove_nationality_from_trainees.rb
@@ -1,0 +1,5 @@
+class RemoveNationalityFromTrainees < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :trainees, :nationality, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_14_163852) do
+ActiveRecord::Schema.define(version: 2020_09_29_163827) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "nationalisations", force: :cascade do |t|
+    t.bigint "trainee_id", null: false
+    t.bigint "nationality_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["nationality_id"], name: "index_nationalisations_on_nationality_id"
+    t.index ["trainee_id"], name: "index_nationalisations_on_trainee_id"
+  end
+
+  create_table "nationalities", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_nationalities_on_name", unique: true
+  end
 
   create_table "trainees", force: :cascade do |t|
     t.text "trainee_id"
@@ -45,6 +61,9 @@ ActiveRecord::Schema.define(version: 2020_09_14_163852) do
     t.text "postcode"
     t.text "phone_number"
     t.text "email"
+    t.date "start_date"
+    t.text "full_time_part_time"
+    t.boolean "teaching_scholars"
     t.text "course_title"
     t.text "course_phase"
     t.date "programme_start_date"
@@ -54,11 +73,11 @@ ActiveRecord::Schema.define(version: 2020_09_14_163852) do
     t.text "itt_subject"
     t.text "employing_school"
     t.text "placement_school"
-    t.date "start_date"
-    t.text "full_time_part_time"
-    t.boolean "teaching_scholars"
     t.uuid "dttp_id"
+    t.text "middle_names"
     t.index ["dttp_id"], name: "index_trainees_on_dttp_id"
   end
 
+  add_foreign_key "nationalisations", "nationalities"
+  add_foreign_key "nationalisations", "trainees"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_29_163827) do
+ActiveRecord::Schema.define(version: 2020_09_30_125009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,7 +37,6 @@ ActiveRecord::Schema.define(version: 2020_09_29_163827) do
     t.text "last_name"
     t.text "gender"
     t.date "date_of_birth"
-    t.text "nationality"
     t.text "ethnicity"
     t.text "disability"
     t.datetime "created_at", precision: 6, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+# Load Nationalities
+
+Settings.nationalities.each do |nationality|
+  Nationality.find_or_create_by(name: nationality)
+end

--- a/spec/controllers/trainees_controller_spec.rb
+++ b/spec/controllers/trainees_controller_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe TraineesController do
         first_names
         last_name
         gender
-        nationality
         ethnicity
         disability
         a_level_1_subject

--- a/spec/factories/nationalities.rb
+++ b/spec/factories/nationalities.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :nationality do
+    sequence(:name) { |n| "nationality #{n}" }
+  end
+end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -7,8 +7,6 @@ FactoryBot.define do
     first_names { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     gender { %w[Female Male Other].sample }
-
-    nationality { Faker::Nation.nationality }
     ethnicity { Faker::Nation.nationality }
     disability { %w[none something].sample }
 
@@ -35,6 +33,7 @@ FactoryBot.define do
     start_date { Time.zone.now }
     full_time_part_time { %w[full_time part_time].sample }
     teaching_scholars { [false, true].sample }
+
     factory :trainee do
       date_of_birth { Faker::Date.birthday(min_age: 18, max_age: 65) }
     end

--- a/spec/features/edit_course_details_spec.rb
+++ b/spec/features/edit_course_details_spec.rb
@@ -20,9 +20,9 @@ feature "edit course details" do
   def and_i_enter_valid_parameters
     course_details_page.course_title.set "Test Course"
     course_details_page.course_phase.set "11-16"
-    set_date_fields("programme_start_date", "10/01/2021")
+    course_details_page.set_date_fields("programme_start_date", "10/01/2021")
     course_details_page.programme_length.set "1 year"
-    set_date_fields("programme_end_date", "10/01/2022")
+    course_details_page.set_date_fields("programme_end_date", "10/01/2022")
     course_details_page.allocation_subject.set "Maths"
     course_details_page.itt_subject.set "Maths"
     course_details_page.employing_school.set "Hillside College"
@@ -32,13 +32,6 @@ feature "edit course details" do
 
   def then_i_am_redirected_to_the_summary_page
     expect(summary_page).to be_displayed(id: trainee.id)
-  end
-
-  def set_date_fields(field_prefix, date_string)
-    day, month, year = date_string.split("/")
-    course_details_page.send("#{field_prefix}_day").set day
-    course_details_page.send("#{field_prefix}_month").set month
-    course_details_page.send("#{field_prefix}_year").set year
   end
 
   def and_the_updated_values_are_visible

--- a/spec/features/trainees/edit_course_details_spec.rb
+++ b/spec/features/trainees/edit_course_details_spec.rb
@@ -19,9 +19,9 @@ feature "edit course details" do
   def and_i_enter_valid_parameters
     course_details_page.course_title.set "Test Course"
     course_details_page.course_phase.set "11-16"
-    set_date_fields("programme_start_date", "10/01/2021")
+    course_details_page.set_date_fields("programme_start_date", "10/01/2021")
     course_details_page.programme_length.set "1 year"
-    set_date_fields("programme_end_date", "10/01/2022")
+    course_details_page.set_date_fields("programme_end_date", "10/01/2022")
     course_details_page.allocation_subject.set "Maths"
     course_details_page.itt_subject.set "Maths"
     course_details_page.employing_school.set "Hillside College"
@@ -31,13 +31,6 @@ feature "edit course details" do
 
   def then_i_am_redirected_to_the_summary_page
     expect(summary_page).to be_displayed(id: trainee.id)
-  end
-
-  def set_date_fields(field_prefix, date_string)
-    day, month, year = date_string.split("/")
-    course_details_page.send("#{field_prefix}_day").set day
-    course_details_page.send("#{field_prefix}_month").set month
-    course_details_page.send("#{field_prefix}_year").set year
   end
 
   def course_details_page

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -26,7 +26,7 @@ feature "edit personal details", type: :feature do
   def and_i_enter_valid_parameters
     @personal_details_page.first_names.set("Tim")
     @personal_details_page.last_name.set("Smith")
-    set_date_fields("dob", "01/01/1986")
+    @personal_details_page.set_date_fields("dob", "01/01/1986")
     @personal_details_page.gender.choose("Male")
     @personal_details_page.nationality.check(@nationality.name.titleize)
     @personal_details_page.submit_button.click
@@ -40,12 +40,5 @@ feature "edit personal details", type: :feature do
   def and_the_personal_details_are_updated
     when_i_visit_the_personal_details_page
     expect(@personal_details_page.first_names.value).to eq("Tim")
-  end
-
-  def set_date_fields(field_prefix, date_string)
-    day, month, year = date_string.split("/")
-    @personal_details_page.send("#{field_prefix}_day").set(day)
-    @personal_details_page.send("#{field_prefix}_month").set(month)
-    @personal_details_page.send("#{field_prefix}_year").set(year)
   end
 end

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+feature "edit personal details", type: :feature do
+  scenario "edit with valid parameters" do
+    given_a_trainee_exists
+    and_nationalities_exist_in_the_system
+    when_i_visit_the_personal_details_page
+    and_i_enter_valid_parameters
+    then_i_am_redirected_to_the_summary_page
+    and_the_personal_details_are_updated
+  end
+
+  def given_a_trainee_exists
+    @trainee = create(:trainee)
+  end
+
+  def and_nationalities_exist_in_the_system
+    @nationality = create(:nationality, name: "british")
+  end
+
+  def when_i_visit_the_personal_details_page
+    @personal_details_page ||= PageObjects::Trainees::PersonalDetails.new
+    @personal_details_page.load(id: @trainee.id)
+  end
+
+  def and_i_enter_valid_parameters
+    @personal_details_page.first_names.set("Tim")
+    @personal_details_page.last_name.set("Smith")
+    set_date_fields("dob", "01/01/1986")
+    @personal_details_page.gender.choose("Male")
+    @personal_details_page.nationality.check(@nationality.name.titleize)
+    @personal_details_page.submit_button.click
+  end
+
+  def then_i_am_redirected_to_the_summary_page
+    @summary_page ||= PageObjects::Trainees::Summary.new
+    expect(@summary_page).to be_displayed(id: @trainee.id)
+  end
+
+  def and_the_personal_details_are_updated
+    when_i_visit_the_personal_details_page
+    expect(@personal_details_page.first_names.value).to eq("Tim")
+  end
+
+  def set_date_fields(field_prefix, date_string)
+    day, month, year = date_string.split("/")
+    @personal_details_page.send("#{field_prefix}_day").set(day)
+    @personal_details_page.send("#{field_prefix}_month").set(month)
+    @personal_details_page.send("#{field_prefix}_year").set(year)
+  end
+end

--- a/spec/features/trainees/edit_training_details_spec.rb
+++ b/spec/features/trainees/edit_training_details_spec.rb
@@ -18,7 +18,7 @@ feature "edit training details" do
   end
 
   def and_i_enter_valid_parameters
-    set_date_fields("start_date", "10/01/2021")
+    @training_details_page.set_date_fields("start_date", "10/01/2021")
     @training_details_page.full_time.click
     @training_details_page.teaching_scholars_yes.click
     @training_details_page.submit_button.click
@@ -26,12 +26,5 @@ feature "edit training details" do
 
   def then_i_am_redirected_to_the_summary_page
     expect(page.current_path).to eq("/trainees/#{@trainee.id}")
-  end
-
-  def set_date_fields(field_prefix, date_string)
-    day, month, year = date_string.split("/")
-    @training_details_page.send("#{field_prefix}_day").set day
-    @training_details_page.send("#{field_prefix}_month").set month
-    @training_details_page.send("#{field_prefix}_year").set year
   end
 end

--- a/spec/helpers/nationalities_helper_spec.rb
+++ b/spec/helpers/nationalities_helper_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe NationalitiesHelper do
+  include NationalitiesHelper
+
+  describe "#format_default_nationalities" do
+    let(:nationality) { build(:nationality, name: name) }
+
+    let(:expected_nationality) do
+      OpenStruct.new(
+        id: nationality.id,
+        name: nationality.name.titleize,
+        description: t("views.default_nationalities.#{nationality.name}.description"),
+      )
+    end
+
+    context "default nationalities" do
+      context "english" do
+        let(:name) { "english" }
+
+        it "returns formatted versions of given nationality records" do
+          expect(format_default_nationalities([nationality])).to include(expected_nationality)
+        end
+      end
+
+      context "irish" do
+        let(:name) { "irish" }
+
+        it "returns formatted versions of given nationality records" do
+          expect(format_default_nationalities([nationality])).to include(expected_nationality)
+        end
+      end
+
+      context "other" do
+        let(:name) { "other" }
+
+        it "returns formatted versions of given nationality records" do
+          expect(format_default_nationalities([nationality])).to include(expected_nationality)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/nationalisation_spec.rb
+++ b/spec/models/nationalisation_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Nationalisation do
   describe "associations" do
-    it { should belong_to(:trainee) }
-    it { should belong_to(:nationality) }
+    it { is_expected.to belong_to(:trainee) }
+    it { is_expected.to belong_to(:nationality) }
   end
 end

--- a/spec/models/nationalisation_spec.rb
+++ b/spec/models/nationalisation_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+describe Nationalisation do
+  describe "associations" do
+    it { should belong_to(:trainee) }
+    it { should belong_to(:nationality) }
+  end
+end

--- a/spec/models/nationality_spec.rb
+++ b/spec/models/nationality_spec.rb
@@ -4,7 +4,7 @@ describe Nationality do
   subject { build(:nationality) }
 
   describe "associations" do
-    it { should have_many(:nationalisations).inverse_of(:nationality) }
-    it { should have_many(:trainees).through(:nationalisations) }
+    it { is_expected.to have_many(:nationalisations).inverse_of(:nationality) }
+    it { is_expected.to have_many(:trainees).through(:nationalisations) }
   end
 end

--- a/spec/models/nationality_spec.rb
+++ b/spec/models/nationality_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+describe Nationality do
+  subject { build(:nationality) }
+
+  describe "associations" do
+    it { should have_many(:nationalisations).inverse_of(:nationality) }
+    it { should have_many(:trainees).through(:nationalisations) }
+  end
+end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 describe Trainee do
   describe "associations" do
-    it { should have_many(:nationalisations).inverse_of(:trainee) }
-    it { should have_many(:nationalities).through(:nationalisations) }
+    it { is_expected.to have_many(:nationalisations).inverse_of(:trainee) }
+    it { is_expected.to have_many(:nationalities).through(:nationalisations) }
   end
 
   describe ".dttp_id" do

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 describe Trainee do
+  describe "associations" do
+    it { should have_many(:nationalisations).inverse_of(:trainee) }
+    it { should have_many(:nationalities).through(:nationalisations) }
+  end
+
   describe ".dttp_id" do
     let(:uuid) { "2795182a-43b2-4543-bf83-ad95fbfce7fd" }
 

--- a/spec/presenters/trainee_personal_details_spec.rb
+++ b/spec/presenters/trainee_personal_details_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe TraineePersonalDetails do
       "Last name",
       "Gender",
       "Date of birth",
-      "Nationality",
       "Ethnicity",
       "Disability",
     ])

--- a/spec/support/page_objects/base.rb
+++ b/spec/support/page_objects/base.rb
@@ -1,3 +1,12 @@
 module PageObjects
+  module Helpers
+    def set_date_fields(field_prefix, date_string)
+      day, month, year = date_string.split("/")
+      send("#{field_prefix}_day").set(day)
+      send("#{field_prefix}_month").set(month)
+      send("#{field_prefix}_year").set(year)
+    end
+  end
+
   class Base < SitePrism::Page; end
 end

--- a/spec/support/page_objects/trainees/course_details.rb
+++ b/spec/support/page_objects/trainees/course_details.rb
@@ -1,6 +1,8 @@
 module PageObjects
   module Trainees
     class CourseDetails < PageObjects::Base
+      include PageObjects::Helpers
+
       set_url "/trainees/{id}/course-details"
       element :submit_button, "input[name='commit']"
       element :course_title, "#trainee-course-title-field"

--- a/spec/support/page_objects/trainees/personal_details.rb
+++ b/spec/support/page_objects/trainees/personal_details.rb
@@ -1,0 +1,15 @@
+module PageObjects
+  module Trainees
+    class PersonalDetails < PageObjects::Base
+      set_url "/trainees/{id}/personal-details"
+      element :first_names, "#trainee-first-names-field"
+      element :last_name, "#trainee-last-name-field"
+      element :dob_day, "#trainee_date_of_birth_3i"
+      element :dob_month, "#trainee_date_of_birth_2i"
+      element :dob_year, "#trainee_date_of_birth_1i"
+      element :gender, ".govuk-radios.gender"
+      element :nationality, ".govuk-checkboxes.nationality"
+      element :submit_button, "input[name='commit']"
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/personal_details.rb
+++ b/spec/support/page_objects/trainees/personal_details.rb
@@ -1,6 +1,8 @@
 module PageObjects
   module Trainees
     class PersonalDetails < PageObjects::Base
+      include PageObjects::Helpers
+
       set_url "/trainees/{id}/personal-details"
       element :first_names, "#trainee-first-names-field"
       element :last_name, "#trainee-last-name-field"

--- a/spec/support/page_objects/trainees/training_details.rb
+++ b/spec/support/page_objects/trainees/training_details.rb
@@ -1,6 +1,8 @@
 module PageObjects
   module Trainees
     class TrainingDetails < PageObjects::Base
+      include PageObjects::Helpers
+
       set_url "/trainees/{id}/training-details"
       element :submit_button, "input[name='commit']"
       element :start_date_day, "#trainee_start_date_3i"

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,6 @@
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/rZaCjwlr/165-s-build-personal-details-form

### Changes proposed in this pull request

<img width="1180" alt="Screenshot 2020-09-30 at 13 16 18" src="https://user-images.githubusercontent.com/616080/94683927-30a63300-031f-11eb-9531-a9dddedc64b2.png">

- Refactor the personal details form to look more closely to the prototype
- Add both a `Nationality` model and a `Nationalisation` join table which allows a trainee to select multiple nationalities
- Implement nationality selection into the form via checkboxes as per the prototype (JS version out of scope)
- Validations out of scope for this ticket
- Confirmation page out of scope for this ticket

### Guidance to review

https://dfe-twd-rttd-pr-60.herokuapp.com/

- Create a trainee and navigate to the personal details section
- Fill in details and submit
- Assert details are saved when returning to the personal details section

