### PR TITLE
[232] Hardcode ruby version in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby File.readlines(".tool-versions", chomp: true).grep(%r{^ruby}).first.split.last
+ruby "2.7.1"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 6.0.3"


### PR DESCRIPTION
### Context
Dependabot can't read `.ruby-version` or `.tool-versions`, see https://github.com/dependabot/dependabot-core/issues/1033

### Changes proposed in this pull request
Hardcode ruby version in Gemfile

### Guidance to review
🚢 
