### PR TITLE
Change additional paths in webpacker

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -11,7 +11,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: ['app/components', 'node_modules/govuk-frontend/govuk']
+  additional_paths: ['app/components', 'node_modules/govuk-frontend/govuk']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
### Context

Hit an issue with testing after a version bump for webpacker https://github.com/DFE-Digital/register-trainee-teacher-data/pull/65

### Changes proposed in this pull request

Changed `resolved_paths` to `additional_paths` as it's deprecated

### Guidance to review

